### PR TITLE
Change emulation id to R_PITAYA for improved detection by HermesIntf.dll

### DIFF
--- a/projects/sdr_receiver_hpsdr/server/sdr-receiver-hpsdr.c
+++ b/projects/sdr_receiver_hpsdr/server/sdr-receiver-hpsdr.c
@@ -42,7 +42,7 @@ int main(int argc, char *argv[])
   volatile void *cfg, *sts, *mux, *ptr;
   char *end, *name = "/dev/mem";
   uint8_t buffer[1032];
-  uint8_t reply[20] = {0xef, 0xfe, 2, 0, 0, 0, 0, 0, 0, 25, 1, 'R', 'T', 'L', '_', 'N', '1', 'G', 'P', 6};
+  uint8_t reply[20] = {0xef, 0xfe, 2, 0, 0, 0, 0, 0, 0, 25, 1, 'R', '_', 'P', 'I', 'T', 'A', 'Y', 'A', 6};
   struct ifreq hwaddr;
   struct sockaddr_in addr_ep2, addr_from;
   socklen_t size_from;


### PR DESCRIPTION
I updated HermesIntf.dll and as of version 16.6.27 it will recognize the R_PITAYA emulation ID.  In case you prefer not to use the RTL Dongle id.  

![image](https://cloud.githubusercontent.com/assets/9923389/16399197/44dd133a-3c9e-11e6-861d-21c2223b3a8d.png)
