### PR TITLE
Patch for opt_design errors due to trimming of unused paths

### DIFF
--- a/cores/axi_sts_register_v1_0/axi_sts_register.v
+++ b/cores/axi_sts_register_v1_0/axi_sts_register.v
@@ -92,5 +92,11 @@ module axi_sts_register #
   assign s_axi_arready = 1'b1;
   assign s_axi_rdata = int_rdata_reg;
   assign s_axi_rvalid = int_rvalid_reg;
+  
+  // Patch for opt_design errors due to trimming of unused paths
+  assign s_axi_bresp = 2'd0;
+  assign s_axi_awready = 1'd0;
+  assign s_axi_bvalid = 1'd0;
+  assign s_axi_wready = 1'd0;
 
 endmodule


### PR DESCRIPTION
In some conditions the status register core causes opt_design errors like this one:

> [Opt 31-67] Problem: A LUT3 cell in the design is missing a connection on input pin I0, which is used by the LUT equation. This pin has either been left unconnected in the design or the connection was removed due to the trimming of unused logic. The LUT cell name is: system_i/axi_interconnect_0/xbar/inst/gen_sasd.crossbar_sasd_0/s_axi_bresp[1]_INST_0.

This happens due to undriven LUTs which are removed in opt_design. The error does not happen in every design and I could not reproduce it. It seems to be rooted deep in the mysteries of the optimization algorithm. The core is working without (known) issues if the commited lines are appended to the code.