### PR TITLE
Enhance AXIS_RAM_WRITER by adding a total counter

### DIFF
--- a/cores/axis_ram_writer_v1_0/axis_ram_writer.v
+++ b/cores/axis_ram_writer_v1_0/axis_ram_writer.v
@@ -88,7 +88,7 @@ module axis_ram_writer #
       int_awvalid_reg <= 1'b0;
       int_wvalid_reg <= 1'b0;
       int_addr_reg <= {(ADDR_WIDTH){1'b0}};
-      int_addr_reg_total <= {(64){1'b0}};
+      int_addr_reg_total <= {(ADDR_WIDTH_COUNTER){1'b0}};
       int_wid_reg <= {(AXI_ID_WIDTH){1'b0}};
     end
     else

--- a/cores/axis_ram_writer_v1_0/axis_ram_writer.v
+++ b/cores/axis_ram_writer_v1_0/axis_ram_writer.v
@@ -82,7 +82,6 @@ module axis_ram_writer #
 
   always @(posedge aclk)
   begin
-    // Prevent locking of the AXI bus due to reset while bursting data
     if(~aresetn)
     begin
       int_awvalid_reg <= 1'b0;

--- a/cores/axis_ram_writer_v1_0/axis_ram_writer.v
+++ b/cores/axis_ram_writer_v1_0/axis_ram_writer.v
@@ -16,8 +16,8 @@ module axis_ram_writer #
   input  wire                        aresetn,
 
   input  wire [AXI_ADDR_WIDTH-1:0]   cfg_data,
-  output wire [ADDR_WIDTH:0]       sts_data,
-  output wire [ADDR_WIDTH_COUNTER:0] sts_total_data,
+  output wire [ADDR_WIDTH-1:0]       sts_data,
+  output wire [ADDR_WIDTH_COUNTER-1:0] sts_total_data,
 
   // Master side
   output wire [AXI_ID_WIDTH-1:0]     m_axi_awid,    // AXI master: Write address ID

--- a/cores/axis_ram_writer_v1_0/axis_ram_writer.v
+++ b/cores/axis_ram_writer_v1_0/axis_ram_writer.v
@@ -4,6 +4,7 @@
 module axis_ram_writer #
 (
   parameter integer ADDR_WIDTH = 20,
+  parameter integer ADDR_WIDTH_COUNTER = 64,
   parameter integer AXI_ID_WIDTH = 6,
   parameter integer AXI_ADDR_WIDTH = 32,
   parameter integer AXI_DATA_WIDTH = 64,
@@ -15,7 +16,8 @@ module axis_ram_writer #
   input  wire                        aresetn,
 
   input  wire [AXI_ADDR_WIDTH-1:0]   cfg_data,
-  output wire [ADDR_WIDTH-1:0]       sts_data,
+  output wire [ADDR_WIDTH:0]       sts_data,
+  output wire [ADDR_WIDTH_COUNTER:0] sts_total_data,
 
   // Master side
   output wire [AXI_ID_WIDTH-1:0]     m_axi_awid,    // AXI master: Write address ID
@@ -50,6 +52,7 @@ module axis_ram_writer #
   reg int_awvalid_reg, int_awvalid_next;
   reg int_wvalid_reg, int_wvalid_next;
   reg [ADDR_WIDTH-1:0] int_addr_reg, int_addr_next;
+  reg [ADDR_WIDTH_COUNTER-1:0] int_addr_reg_total, int_addr_next_total;
   reg [AXI_ID_WIDTH-1:0] int_wid_reg, int_wid_next;
 
   wire int_full_wire, int_empty_wire, int_rden_wire;
@@ -79,11 +82,13 @@ module axis_ram_writer #
 
   always @(posedge aclk)
   begin
+    // Prevent locking of the AXI bus due to reset while bursting data
     if(~aresetn)
     begin
       int_awvalid_reg <= 1'b0;
       int_wvalid_reg <= 1'b0;
       int_addr_reg <= {(ADDR_WIDTH){1'b0}};
+      int_addr_reg_total <= {(64){1'b0}};
       int_wid_reg <= {(AXI_ID_WIDTH){1'b0}};
     end
     else
@@ -91,6 +96,7 @@ module axis_ram_writer #
       int_awvalid_reg <= int_awvalid_next;
       int_wvalid_reg <= int_wvalid_next;
       int_addr_reg <= int_addr_next;
+      int_addr_reg_total <= int_addr_next_total;
       int_wid_reg <= int_wid_next;
     end
   end
@@ -100,6 +106,7 @@ module axis_ram_writer #
     int_awvalid_next = int_awvalid_reg;
     int_wvalid_next = int_wvalid_reg;
     int_addr_next = int_addr_reg;
+    int_addr_next_total = int_addr_reg_total;
     int_wid_next = int_wid_reg;
 
     if(~int_empty_wire & ~int_awvalid_reg & ~int_wvalid_reg)
@@ -116,6 +123,7 @@ module axis_ram_writer #
     if(int_rden_wire)
     begin
       int_addr_next = int_addr_reg + 1'b1;
+      int_addr_next_total = int_addr_reg_total + 1'b1;
     end
 
     if(m_axi_wready & int_wlast_wire)
@@ -133,6 +141,7 @@ module axis_ram_writer #
   end
 
   assign sts_data = int_addr_reg;
+  assign sts_total_data = int_addr_reg_total;
 
   assign m_axi_awid = int_wid_reg;
   assign m_axi_awaddr = cfg_data + {int_addr_reg, {(ADDR_SIZE){1'b0}}};

--- a/cores/axis_ram_writer_v1_0/core_config.tcl
+++ b/cores/axis_ram_writer_v1_0/core_config.tcl
@@ -10,6 +10,7 @@ core_parameter AXI_ADDR_WIDTH {AXI ADDR WIDTH} {Width of the AXI address bus.}
 core_parameter AXI_ID_WIDTH {AXI ID WIDTH} {Width of the AXI ID bus.}
 core_parameter AXIS_TDATA_WIDTH {AXIS TDATA WIDTH} {Width of the S_AXIS data bus.}
 core_parameter ADDR_WIDTH {ADDR WIDTH} {Width of the address.}
+core_parameter ADDR_WIDTH_COUNTER {ADDR_WIDTH_COUNTER} {Width of the total counter.}
 
 set address [ipx::get_address_spaces m_axi -of_objects $core]
 set_property NAME M_AXI $address


### PR DESCRIPTION
We extended the `axis_ram_writer` to keep track of the total number of samples written. This is quite convenient in a client server setting, where the client only reads partial data. Then, even if the ram overflows, one can determine the total sample number. This is my first time I touch verilog code. So apologies if there are things wrong, or if the naming is not perfect. I tested it and it seems to work.