### PR TITLE
Adjust sdr_receiver_hpsdr and sdr_transceiver_hpsdr to be compatible with recent changes

### DIFF
--- a/projects/sdr_receiver_hpsdr/rx.tcl
+++ b/projects/sdr_receiver_hpsdr/rx.tcl
@@ -260,7 +260,7 @@ for {set i 0} {$i <= 7} {incr i} {
   }
 
   # Create axis_fifo
-  cell pavel-demin:user:axis_fifo fifo_$i {
+  cell pavel-demin:user:axis_fifo:1.0 fifo_$i {
     S_AXIS_TDATA_WIDTH 64
     M_AXIS_TDATA_WIDTH 32
   } {

--- a/projects/sdr_transceiver_hpsdr/codec.tcl
+++ b/projects/sdr_transceiver_hpsdr/codec.tcl
@@ -45,7 +45,7 @@ cell xilinx.com:ip:fifo_generator fifo_generator_0 {
 }
 
 # Create axis_fifo
-cell pavel-demin:user:axis_fifo fifo_0 {
+cell pavel-demin:user:axis_fifo:1.0 fifo_0 {
   S_AXIS_TDATA_WIDTH 32
   M_AXIS_TDATA_WIDTH 32
 } {
@@ -90,7 +90,7 @@ cell pavel-demin:user:axi_bram_writer writer_1 {
   BRAM_DATA_WIDTH 32
   BRAM_ADDR_WIDTH 9
 } {
-  BRAM_PORTA bram_0/BRAM_PORTA
+  B_BRAM bram_0/BRAM_PORTA
 }
 
 # Create axis_keyer
@@ -99,7 +99,7 @@ cell pavel-demin:user:axis_keyer keyer_0 {
   BRAM_DATA_WIDTH 16
   BRAM_ADDR_WIDTH 10
 } {
-  BRAM_PORTA bram_0/BRAM_PORTB
+  B_BRAM bram_0/BRAM_PORTB
   cfg_data slice_3/dout
   aclk /pll_0/clk_out1
   aresetn /rst_0/peripheral_aresetn
@@ -240,7 +240,7 @@ cell xilinx.com:ip:axis_subset_converter subset_2 {
 }
 
 # Create axis_fifo
-cell pavel-demin:user:axis_fifo fifo_1 {
+cell pavel-demin:user:axis_fifo:1.0 fifo_1 {
   S_AXIS_TDATA_WIDTH 32
   M_AXIS_TDATA_WIDTH 32
 } {

--- a/projects/sdr_transceiver_hpsdr/rx.tcl
+++ b/projects/sdr_transceiver_hpsdr/rx.tcl
@@ -325,7 +325,7 @@ for {set i 0} {$i <= 4} {incr i} {
   }
 
   # Create axis_fifo
-  cell pavel-demin:user:axis_fifo fifo_$i {
+  cell pavel-demin:user:axis_fifo:1.0 fifo_$i {
     S_AXIS_TDATA_WIDTH 64
     M_AXIS_TDATA_WIDTH 32
   } {

--- a/projects/sdr_transceiver_hpsdr/tx.tcl
+++ b/projects/sdr_transceiver_hpsdr/tx.tcl
@@ -44,7 +44,7 @@ cell xilinx.com:ip:fifo_generator fifo_generator_0 {
 }
 
 # Create axis_fifo
-cell pavel-demin:user:axis_fifo fifo_0 {
+cell pavel-demin:user:axis_fifo:1.0 fifo_0 {
   S_AXIS_TDATA_WIDTH 32
   M_AXIS_TDATA_WIDTH 64
 } {
@@ -200,7 +200,7 @@ cell pavel-demin:user:axi_bram_writer writer_1 {
   BRAM_DATA_WIDTH 32
   BRAM_ADDR_WIDTH 10
 } {
-  BRAM_PORTA bram_0/BRAM_PORTA
+  B_BRAM bram_0/BRAM_PORTA
 }
 
 # Create axis_keyer
@@ -209,7 +209,7 @@ cell pavel-demin:user:axis_keyer keyer_0 {
   BRAM_DATA_WIDTH 32
   BRAM_ADDR_WIDTH 10
 } {
-  BRAM_PORTA bram_0/BRAM_PORTB
+  B_BRAM bram_0/BRAM_PORTB
   cfg_data slice_2/dout
   aclk /pll_0/clk_out1
   aresetn /rst_0/peripheral_aresetn


### PR DESCRIPTION
A couple of recent changes (simplications and also a new fifo version) broke the build of these SDR projects. These minor changes result in the build succeeding. Note this has not yet been verified as functioning.