### PR TITLE
Hold max-abs output under backpressure

### DIFF
--- a/cores/axis_maxabs_finder.v
+++ b/cores/axis_maxabs_finder.v
@@ -31,6 +31,7 @@ module axis_maxabs_finder #
 
   wire [AXIS_TDATA_WIDTH-1:0] int_abs_wire;
   wire int_comp_wire;
+  wire input_transfer;
 
   always @(posedge aclk)
   begin
@@ -60,13 +61,18 @@ module axis_maxabs_finder #
     int_cntr_next = int_cntr_reg;
     int_tvalid_next = int_tvalid_reg;
 
-    if(s_axis_tvalid & int_comp_wire)
+    if(m_axis_tready & int_tvalid_reg)
+    begin
+      int_tvalid_next = 1'b0;
+    end
+
+    if(input_transfer & int_comp_wire)
     begin
       int_max_next = int_abs_wire > int_max_reg ? int_abs_wire : int_max_reg;
       int_cntr_next = int_cntr_reg + 1'b1;
     end
 
-    if(s_axis_tvalid & ~int_comp_wire)
+    if(input_transfer & ~int_comp_wire)
     begin
       int_max_next = {(AXIS_TDATA_WIDTH){1'b0}};
       int_tdata_next = int_max_reg;
@@ -74,13 +80,10 @@ module axis_maxabs_finder #
       int_tvalid_next = 1'b1;
     end
 
-    if(m_axis_tready & int_tvalid_reg)
-    begin
-      int_tvalid_next = 1'b0;
-    end
   end
 
-  assign s_axis_tready = 1'b1;
+  assign s_axis_tready = ~int_tvalid_reg | m_axis_tready;
+  assign input_transfer = s_axis_tvalid & s_axis_tready;
   assign m_axis_tdata = int_tdata_reg;
   assign m_axis_tvalid = int_tvalid_reg;
 

--- a/cores/axis_maxabs_finder.v
+++ b/cores/axis_maxabs_finder.v
@@ -24,67 +24,35 @@ module axis_maxabs_finder #
   output wire                        m_axis_tvalid
 );
 
-  reg [AXIS_TDATA_WIDTH-1:0] int_max_reg, int_max_next;
-  reg [AXIS_TDATA_WIDTH-1:0] int_tdata_reg, int_tdata_next;
-  reg [CNTR_WIDTH-1:0] int_cntr_reg, int_cntr_next;
-  reg int_tvalid_reg, int_tvalid_next;
+  reg [AXIS_TDATA_WIDTH-1:0] int_max_reg;
+  reg [CNTR_WIDTH-1:0] int_cntr_reg;
 
   wire [AXIS_TDATA_WIDTH-1:0] int_abs_wire;
-  wire int_comp_wire;
-  wire input_transfer;
+  wire int_last_wire;
+
+  assign int_last_wire = int_cntr_reg == cfg_data;
+  assign int_abs_wire = s_axis_tdata[AXIS_TDATA_WIDTH-1] ? ~s_axis_tdata : s_axis_tdata;
 
   always @(posedge aclk)
   begin
     if(~aresetn)
     begin
       int_max_reg <= {(AXIS_TDATA_WIDTH){1'b0}};
-      int_tdata_reg <= {(AXIS_TDATA_WIDTH){1'b0}};
       int_cntr_reg <= {(CNTR_WIDTH){1'b0}};
-      int_tvalid_reg <= 1'b0;
     end
-    else
+    else if(s_axis_tvalid & s_axis_tready)
     begin
-      int_max_reg <= int_max_next;
-      int_tdata_reg <= int_tdata_next;
-      int_cntr_reg <= int_cntr_next;
-      int_tvalid_reg <= int_tvalid_next;
+      int_max_reg <= int_last_wire ? {(AXIS_TDATA_WIDTH){1'b0}} : int_abs_wire > int_max_reg ? int_abs_wire : int_max_reg;
+      int_cntr_reg <= int_last_wire ? {(CNTR_WIDTH){1'b0}} : int_cntr_reg + 1'b1;
     end
   end
 
-  assign int_comp_wire = int_cntr_reg < cfg_data;
-  assign int_abs_wire = s_axis_tdata[AXIS_TDATA_WIDTH-1] ? ~s_axis_tdata : s_axis_tdata;
-
-  always @*
-  begin
-    int_max_next = int_max_reg;
-    int_tdata_next = int_tdata_reg;
-    int_cntr_next = int_cntr_reg;
-    int_tvalid_next = int_tvalid_reg;
-
-    if(m_axis_tready & int_tvalid_reg)
-    begin
-      int_tvalid_next = 1'b0;
-    end
-
-    if(input_transfer & int_comp_wire)
-    begin
-      int_max_next = int_abs_wire > int_max_reg ? int_abs_wire : int_max_reg;
-      int_cntr_next = int_cntr_reg + 1'b1;
-    end
-
-    if(input_transfer & ~int_comp_wire)
-    begin
-      int_max_next = {(AXIS_TDATA_WIDTH){1'b0}};
-      int_tdata_next = int_max_reg;
-      int_cntr_next = {(CNTR_WIDTH){1'b0}};
-      int_tvalid_next = 1'b1;
-    end
-
-  end
-
-  assign s_axis_tready = ~int_tvalid_reg | m_axis_tready;
-  assign input_transfer = s_axis_tvalid & s_axis_tready;
-  assign m_axis_tdata = int_tdata_reg;
-  assign m_axis_tvalid = int_tvalid_reg;
+  output_buffer #(
+    .DATA_WIDTH(AXIS_TDATA_WIDTH)
+  ) buf_0 (
+    .aclk(aclk), .aresetn(aresetn),
+    .in_data(int_max_reg), .in_valid(s_axis_tvalid & int_last_wire), .in_ready(s_axis_tready),
+    .out_data(m_axis_tdata), .out_valid(m_axis_tvalid), .out_ready(m_axis_tready)
+  );
 
 endmodule

--- a/cores/axis_maxabs_finder.v
+++ b/cores/axis_maxabs_finder.v
@@ -30,7 +30,7 @@ module axis_maxabs_finder #
   wire [AXIS_TDATA_WIDTH-1:0] int_abs_wire;
   wire int_last_wire;
 
-  assign int_last_wire = int_cntr_reg == cfg_data;
+  assign int_last_wire = int_cntr_reg >= cfg_data;
   assign int_abs_wire = s_axis_tdata[AXIS_TDATA_WIDTH-1] ? ~s_axis_tdata : s_axis_tdata;
 
   always @(posedge aclk)


### PR DESCRIPTION
## Summary

Hold the max-absolute-value AXI-Stream output stable under backpressure.

## Root cause

The block kept its input ready while a stalled output remained valid. Later windows could overwrite the pending payload. Input state also advanced without an accepted transfer.

## Validation

The RTL-only patch was checked locally with a directed Icarus Verilog backpressure test plus Verilator lint. No testbench or lint artifacts are included in this PR.
