### PR TITLE
Preserve AXI source transfers

### DIFF
--- a/cores/axis_pulse_generator.v
+++ b/cores/axis_pulse_generator.v
@@ -34,13 +34,13 @@ module axis_pulse_generator
     begin
       int_cntr_reg <= int_cntr_reg - 1'b1;
     end
-    else if(s_axis_tvalid)
+    else if(s_axis_tvalid & s_axis_tready)
     begin
       int_cntr_reg <= s_axis_tdata[63:32];
     end
   end
 
-  assign s_axis_tready = int_tready_wire;
+  assign s_axis_tready = int_tready_wire & m_axis_tready;
 
   assign m_axis_tdata = s_axis_tdata[15:0];
   assign m_axis_tvalid = int_tready_wire & s_axis_tvalid;

--- a/cores/axis_pulse_generator.v
+++ b/cores/axis_pulse_generator.v
@@ -3,6 +3,7 @@
 
 module axis_pulse_generator
 (
+  // System signals
   input  wire        aclk,
   input  wire        aresetn,
 
@@ -19,10 +20,10 @@ module axis_pulse_generator
 
   reg [31:0] int_cntr_reg;
 
-  wire int_enbl_wire, int_tready_wire;
+  wire int_enbl_wire, int_idle_wire;
 
   assign int_enbl_wire = |int_cntr_reg;
-  assign int_tready_wire = ~int_enbl_wire;
+  assign int_idle_wire = ~int_enbl_wire;
 
   always @(posedge aclk)
   begin
@@ -34,15 +35,15 @@ module axis_pulse_generator
     begin
       int_cntr_reg <= int_cntr_reg - 1'b1;
     end
-    else if(s_axis_tvalid & s_axis_tready)
+    else if(s_axis_tvalid & m_axis_tready)
     begin
       int_cntr_reg <= s_axis_tdata[63:32];
     end
   end
 
-  assign s_axis_tready = int_tready_wire & m_axis_tready;
+  assign s_axis_tready = m_axis_tready & int_idle_wire;
 
   assign m_axis_tdata = s_axis_tdata[15:0];
-  assign m_axis_tvalid = int_tready_wire & s_axis_tvalid;
+  assign m_axis_tvalid = s_axis_tvalid & int_idle_wire;
 
 endmodule

--- a/cores/axis_stepper.v
+++ b/cores/axis_stepper.v
@@ -22,7 +22,7 @@ module axis_stepper #
   output wire                        m_axis_tvalid
 );
 
-  assign s_axis_tready = trg_flag;
+  assign s_axis_tready = trg_flag & m_axis_tready;
   assign m_axis_tdata = s_axis_tdata;
   assign m_axis_tvalid = s_axis_tvalid;
 

--- a/cores/axis_stepper.v
+++ b/cores/axis_stepper.v
@@ -24,6 +24,6 @@ module axis_stepper #
 
   assign s_axis_tready = trg_flag & m_axis_tready;
   assign m_axis_tdata = s_axis_tdata;
-  assign m_axis_tvalid = s_axis_tvalid;
+  assign m_axis_tvalid = s_axis_tvalid & trg_flag;
 
 endmodule

--- a/cores/axis_stepper.v
+++ b/cores/axis_stepper.v
@@ -22,7 +22,7 @@ module axis_stepper #
   output wire                        m_axis_tvalid
 );
 
-  assign s_axis_tready = trg_flag & m_axis_tready;
+  assign s_axis_tready = m_axis_tready & trg_flag;
   assign m_axis_tdata = s_axis_tdata;
   assign m_axis_tvalid = s_axis_tvalid & trg_flag;
 

--- a/cores/axis_variable.v
+++ b/cores/axis_variable.v
@@ -18,11 +18,18 @@ module axis_variable #
   output wire                        m_axis_tvalid
 );
 
+  reg  int_init_reg;
+
+  always @(posedge aclk)
+  begin
+    int_init_reg <= ~aresetn;
+  end
+
   output_buffer #(
     .DATA_WIDTH(AXIS_TDATA_WIDTH)
   ) buf_0 (
     .aclk(aclk), .aresetn(aresetn),
-    .in_data(cfg_data), .in_valid(m_axis_tdata != cfg_data), .in_ready(),
+    .in_data(cfg_data), .in_valid(int_init_reg | (m_axis_tdata != cfg_data)), .in_ready(),
     .out_data(m_axis_tdata), .out_valid(m_axis_tvalid), .out_ready(m_axis_tready)
   );
 

--- a/cores/axis_variable.v
+++ b/cores/axis_variable.v
@@ -28,10 +28,10 @@ module axis_variable #
       int_tdata_reg <= {(AXIS_TDATA_WIDTH){1'b0}};
       int_tvalid_reg <= 1'b0;
     end
-    else
+    else if(~int_tvalid_reg | m_axis_tready)
     begin
       int_tdata_reg <= cfg_data;
-      int_tvalid_reg <= (int_tdata_reg != cfg_data) | (int_tvalid_reg & ~m_axis_tready);
+      int_tvalid_reg <= int_tdata_reg != cfg_data;
     end
   end
 

--- a/cores/axis_variable.v
+++ b/cores/axis_variable.v
@@ -18,24 +18,12 @@ module axis_variable #
   output wire                        m_axis_tvalid
 );
 
-  reg [AXIS_TDATA_WIDTH-1:0] int_tdata_reg;
-  reg int_tvalid_reg;
-
-  always @(posedge aclk)
-  begin
-    if(~aresetn)
-    begin
-      int_tdata_reg <= {(AXIS_TDATA_WIDTH){1'b0}};
-      int_tvalid_reg <= 1'b0;
-    end
-    else if(~int_tvalid_reg | m_axis_tready)
-    begin
-      int_tdata_reg <= cfg_data;
-      int_tvalid_reg <= int_tdata_reg != cfg_data;
-    end
-  end
-
-  assign m_axis_tdata = int_tdata_reg;
-  assign m_axis_tvalid = int_tvalid_reg;
+  output_buffer #(
+    .DATA_WIDTH(AXIS_TDATA_WIDTH)
+  ) buf_0 (
+    .aclk(aclk), .aresetn(aresetn),
+    .in_data(cfg_data), .in_valid(m_axis_tdata != cfg_data), .in_ready(),
+    .out_data(m_axis_tdata), .out_valid(m_axis_tvalid), .out_ready(m_axis_tready)
+  );
 
 endmodule

--- a/cores/axis_variant.v
+++ b/cores/axis_variant.v
@@ -22,7 +22,7 @@ module axis_variant #
 );
 
   reg [AXIS_TDATA_WIDTH-1:0] int_tdata_reg;
-  reg int_tvalid_reg, int_tvalid_next;
+  reg int_tvalid_reg;
   wire [AXIS_TDATA_WIDTH-1:0] int_tdata_wire;
 
   assign int_tdata_wire = cfg_flag ? cfg_data1 : cfg_data0;
@@ -34,25 +34,10 @@ module axis_variant #
       int_tdata_reg <= {(AXIS_TDATA_WIDTH){1'b0}};
       int_tvalid_reg <= 1'b0;
     end
-    else
+    else if(~int_tvalid_reg | m_axis_tready)
     begin
       int_tdata_reg <= int_tdata_wire;
-      int_tvalid_reg <= int_tvalid_next;
-    end
-  end
-
-  always @*
-  begin
-    int_tvalid_next = int_tvalid_reg;
-
-    if(int_tdata_reg != int_tdata_wire)
-    begin
-      int_tvalid_next = 1'b1;
-    end
-
-    if(m_axis_tready & int_tvalid_reg)
-    begin
-      int_tvalid_next = 1'b0;
+      int_tvalid_reg <= int_tdata_reg != int_tdata_wire;
     end
   end
 

--- a/cores/axis_variant.v
+++ b/cores/axis_variant.v
@@ -21,16 +21,24 @@ module axis_variant #
   output wire                        m_axis_tvalid
 );
 
+  reg  int_init_reg;
+
   wire [AXIS_TDATA_WIDTH-1:0] int_data_wire;
 
   assign int_data_wire = cfg_flag ? cfg_data1 : cfg_data0;
+
+  always @(posedge aclk)
+  begin
+    int_init_reg <= ~aresetn;
+  end
 
   output_buffer #(
     .DATA_WIDTH(AXIS_TDATA_WIDTH)
   ) buf_0 (
     .aclk(aclk), .aresetn(aresetn),
-    .in_data(int_data_wire), .in_valid(m_axis_tdata != int_data_wire), .in_ready(),
+    .in_data(int_data_wire), .in_valid(int_init_reg | (m_axis_tdata != int_data_wire)), .in_ready(),
     .out_data(m_axis_tdata), .out_valid(m_axis_tvalid), .out_ready(m_axis_tready)
   );
+
 
 endmodule

--- a/cores/axis_variant.v
+++ b/cores/axis_variant.v
@@ -21,27 +21,16 @@ module axis_variant #
   output wire                        m_axis_tvalid
 );
 
-  reg [AXIS_TDATA_WIDTH-1:0] int_tdata_reg;
-  reg int_tvalid_reg;
-  wire [AXIS_TDATA_WIDTH-1:0] int_tdata_wire;
+  wire [AXIS_TDATA_WIDTH-1:0] int_data_wire;
 
-  assign int_tdata_wire = cfg_flag ? cfg_data1 : cfg_data0;
+  assign int_data_wire = cfg_flag ? cfg_data1 : cfg_data0;
 
-  always @(posedge aclk)
-  begin
-    if(~aresetn)
-    begin
-      int_tdata_reg <= {(AXIS_TDATA_WIDTH){1'b0}};
-      int_tvalid_reg <= 1'b0;
-    end
-    else if(~int_tvalid_reg | m_axis_tready)
-    begin
-      int_tdata_reg <= int_tdata_wire;
-      int_tvalid_reg <= int_tdata_reg != int_tdata_wire;
-    end
-  end
-
-  assign m_axis_tdata = int_tdata_reg;
-  assign m_axis_tvalid = int_tvalid_reg;
+  output_buffer #(
+    .DATA_WIDTH(AXIS_TDATA_WIDTH)
+  ) buf_0 (
+    .aclk(aclk), .aresetn(aresetn),
+    .in_data(int_data_wire), .in_valid(m_axis_tdata != int_data_wire), .in_ready(),
+    .out_data(m_axis_tdata), .out_valid(m_axis_tvalid), .out_ready(m_axis_tready)
+  );
 
 endmodule


### PR DESCRIPTION
These AXI sources currently mutate stalled payloads or acknowledge pass-through transfers before the sink accepts them. `axis_variant` can also lose a replacement update on the consuming cycle.

Only update configuration payloads when the output has capacity. Propagate downstream readiness through the two pass-through paths, then qualify pulse state changes with the actual input transfer.

A directed Verilator probe covers prolonged stalls plus simultaneous consume-and-replace behavior across all four modules.
