### PR TITLE
Hold reduction results through backpressure

### DIFF
--- a/cores/axis_accumulator.v
+++ b/cores/axis_accumulator.v
@@ -27,37 +27,13 @@ module axis_accumulator #
   output wire                          m_axis_tvalid
 );
 
-  reg [M_AXIS_TDATA_WIDTH-1:0] int_tdata_reg, int_tdata_next;
-  reg [M_AXIS_TDATA_WIDTH-1:0] int_accu_reg, int_accu_next;
-  reg [CNTR_WIDTH-1:0] int_cntr_reg, int_cntr_next;
-  reg int_tvalid_reg, int_tvalid_next;
-  reg int_tready_reg, int_tready_next;
+  reg [M_AXIS_TDATA_WIDTH-1:0] int_accu_reg;
+  reg [CNTR_WIDTH-1:0] int_cntr_reg;
 
   wire [M_AXIS_TDATA_WIDTH-1:0] sum_accu_wire;
-  wire int_comp_wire, int_tvalid_wire;
+  wire int_last_wire, int_ready_wire;
 
-  always @(posedge aclk)
-  begin
-    if(~aresetn)
-    begin
-      int_tdata_reg <= {(M_AXIS_TDATA_WIDTH){1'b0}};
-      int_tvalid_reg <= 1'b0;
-      int_tready_reg <= 1'b0;
-      int_accu_reg <= {(M_AXIS_TDATA_WIDTH){1'b0}};
-      int_cntr_reg <= {(CNTR_WIDTH){1'b0}};
-    end
-    else
-    begin
-      int_tdata_reg <= int_tdata_next;
-      int_tvalid_reg <= int_tvalid_next;
-      int_tready_reg <= int_tready_next;
-      int_accu_reg <= int_accu_next;
-      int_cntr_reg <= int_cntr_next;
-    end
-  end
-
-  assign int_comp_wire = int_cntr_reg < cfg_data;
-  assign int_tvalid_wire = s_axis_tready & s_axis_tvalid;
+  assign int_last_wire = int_cntr_reg >= cfg_data;
 
   generate
     if(AXIS_TDATA_SIGNED == "TRUE")
@@ -73,79 +49,56 @@ module axis_accumulator #
   generate
     if(CONTINUOUS == "TRUE")
     begin : CONTINUE
-      always @*
-      begin
-        int_tdata_next = int_tdata_reg;
-        int_tvalid_next = int_tvalid_reg;
-        int_tready_next = int_tready_reg;
-        int_accu_next = int_accu_reg;
-        int_cntr_next = int_cntr_reg;
-
-        if(~int_tready_reg & int_comp_wire)
-        begin
-          int_tready_next = 1'b1;
-        end
-
-        if(m_axis_tready & int_tvalid_reg)
-        begin
-          int_tvalid_next = 1'b0;
-        end
-
-        if(int_tvalid_wire & int_comp_wire)
-        begin
-          int_cntr_next = int_cntr_reg + 1'b1;
-          int_accu_next = sum_accu_wire;
-        end
-
-        if(int_tvalid_wire & ~int_comp_wire)
-        begin
-          int_cntr_next = {(CNTR_WIDTH){1'b0}};
-          int_accu_next = {(M_AXIS_TDATA_WIDTH){1'b0}};
-          int_tdata_next = sum_accu_wire;
-          int_tvalid_next = 1'b1;
-        end
-
-      end
+      assign s_axis_tready = int_ready_wire;
     end
     else
     begin : STOP
-      always @*
+      reg int_ready_reg;
+
+      always @(posedge aclk)
       begin
-        int_tdata_next = int_tdata_reg;
-        int_tvalid_next = int_tvalid_reg;
-        int_tready_next = int_tready_reg;
-        int_accu_next = int_accu_reg;
-        int_cntr_next = int_cntr_reg;
-
-        if(~int_tready_reg & int_comp_wire)
+        if(~aresetn)
         begin
-          int_tready_next = 1'b1;
+          int_ready_reg <= 1'b1;
         end
-
-        if(m_axis_tready & int_tvalid_reg)
+        else if(s_axis_tvalid & s_axis_tready & int_last_wire)
         begin
-          int_tvalid_next = 1'b0;
+          int_ready_reg <= 1'b0;
         end
-
-        if(int_tvalid_wire & int_comp_wire)
-        begin
-          int_cntr_next = int_cntr_reg + 1'b1;
-          int_accu_next = sum_accu_wire;
-        end
-
-        if(int_tvalid_wire & ~int_comp_wire)
-        begin
-          int_tready_next = 1'b0;
-          int_tdata_next = sum_accu_wire;
-          int_tvalid_next = 1'b1;
-        end
-
       end
+
+      assign s_axis_tready = int_ready_wire & int_ready_reg;
     end
   endgenerate
 
-  assign s_axis_tready = int_tready_reg & (~int_tvalid_reg | m_axis_tready);
-  assign m_axis_tdata = int_tdata_reg;
-  assign m_axis_tvalid = int_tvalid_reg;
+  always @(posedge aclk)
+  begin
+    if(~aresetn)
+    begin
+      int_accu_reg <= {(M_AXIS_TDATA_WIDTH){1'b0}};
+      int_cntr_reg <= {(CNTR_WIDTH){1'b0}};
+    end
+    else if(s_axis_tvalid & s_axis_tready)
+    begin
+      if(int_last_wire)
+      begin
+        int_accu_reg <= {(M_AXIS_TDATA_WIDTH){1'b0}};
+        int_cntr_reg <= {(CNTR_WIDTH){1'b0}};
+      end
+      else
+      begin
+        int_accu_reg <= sum_accu_wire;
+        int_cntr_reg <= int_cntr_reg + 1'b1;
+      end
+    end
+  end
+
+  output_buffer #(
+    .DATA_WIDTH(M_AXIS_TDATA_WIDTH)
+  ) buf_0 (
+    .aclk(aclk), .aresetn(aresetn),
+    .in_data(sum_accu_wire), .in_valid(s_axis_tvalid & int_last_wire), .in_ready(int_ready_wire),
+    .out_data(m_axis_tdata), .out_valid(m_axis_tvalid), .out_ready(m_axis_tready)
+  );
 
 endmodule

--- a/cores/axis_accumulator.v
+++ b/cores/axis_accumulator.v
@@ -57,7 +57,7 @@ module axis_accumulator #
   end
 
   assign int_comp_wire = int_cntr_reg < cfg_data;
-  assign int_tvalid_wire = int_tready_reg & s_axis_tvalid;
+  assign int_tvalid_wire = s_axis_tready & s_axis_tvalid;
 
   generate
     if(AXIS_TDATA_SIGNED == "TRUE")
@@ -86,6 +86,11 @@ module axis_accumulator #
           int_tready_next = 1'b1;
         end
 
+        if(m_axis_tready & int_tvalid_reg)
+        begin
+          int_tvalid_next = 1'b0;
+        end
+
         if(int_tvalid_wire & int_comp_wire)
         begin
           int_cntr_next = int_cntr_reg + 1'b1;
@@ -100,10 +105,6 @@ module axis_accumulator #
           int_tvalid_next = 1'b1;
         end
 
-        if(m_axis_tready & int_tvalid_reg)
-        begin
-          int_tvalid_next = 1'b0;
-        end
       end
     end
     else
@@ -121,6 +122,11 @@ module axis_accumulator #
           int_tready_next = 1'b1;
         end
 
+        if(m_axis_tready & int_tvalid_reg)
+        begin
+          int_tvalid_next = 1'b0;
+        end
+
         if(int_tvalid_wire & int_comp_wire)
         begin
           int_cntr_next = int_cntr_reg + 1'b1;
@@ -134,15 +140,11 @@ module axis_accumulator #
           int_tvalid_next = 1'b1;
         end
 
-        if(m_axis_tready & int_tvalid_reg)
-        begin
-          int_tvalid_next = 1'b0;
-        end
       end
     end
   endgenerate
 
-  assign s_axis_tready = int_tready_reg;
+  assign s_axis_tready = int_tready_reg & (~int_tvalid_reg | m_axis_tready);
   assign m_axis_tdata = int_tdata_reg;
   assign m_axis_tvalid = int_tvalid_reg;
 

--- a/cores/axis_decimator.v
+++ b/cores/axis_decimator.v
@@ -24,67 +24,30 @@ module axis_decimator #
   output wire                        m_axis_tvalid
 );
 
-  reg [AXIS_TDATA_WIDTH-1:0] int_tdata_reg, int_tdata_next;
-  reg [CNTR_WIDTH-1:0] int_cntr_reg, int_cntr_next;
-  reg int_tvalid_reg, int_tvalid_next;
-  reg int_tready_reg, int_tready_next;
+  reg [CNTR_WIDTH-1:0] int_cntr_reg;
 
-  wire int_comp_wire, int_tvalid_wire;
+  wire int_last_wire;
+
+  assign int_last_wire = int_cntr_reg >= cfg_data;
 
   always @(posedge aclk)
   begin
     if(~aresetn)
     begin
-      int_tdata_reg <= {(AXIS_TDATA_WIDTH){1'b0}};
-      int_tvalid_reg <= 1'b0;
-      int_tready_reg <= 1'b0;
       int_cntr_reg <= {(CNTR_WIDTH){1'b0}};
     end
-    else
+    else if(s_axis_tvalid & s_axis_tready)
     begin
-      int_tdata_reg <= int_tdata_next;
-      int_tvalid_reg <= int_tvalid_next;
-      int_tready_reg <= int_tready_next;
-      int_cntr_reg <= int_cntr_next;
+      int_cntr_reg <= int_last_wire ? {(CNTR_WIDTH){1'b0}} : int_cntr_reg + 1'b1;
     end
   end
 
-  assign int_comp_wire = int_cntr_reg < cfg_data;
-  assign int_tvalid_wire = s_axis_tready & s_axis_tvalid;
-
-  always @*
-  begin
-    int_tdata_next = int_tdata_reg;
-    int_tvalid_next = int_tvalid_reg;
-    int_tready_next = int_tready_reg;
-    int_cntr_next = int_cntr_reg;
-
-    if(~int_tready_reg & int_comp_wire)
-    begin
-      int_tready_next = 1'b1;
-    end
-
-    if(m_axis_tready & int_tvalid_reg)
-    begin
-      int_tvalid_next = 1'b0;
-    end
-
-    if(int_tvalid_wire & int_comp_wire)
-    begin
-      int_cntr_next = int_cntr_reg + 1'b1;
-    end
-
-    if(int_tvalid_wire & ~int_comp_wire)
-    begin
-      int_cntr_next = {(CNTR_WIDTH){1'b0}};
-      int_tdata_next = s_axis_tdata;
-      int_tvalid_next = 1'b1;
-    end
-
-  end
-
-  assign s_axis_tready = int_tready_reg & (~int_tvalid_reg | m_axis_tready);
-  assign m_axis_tdata = int_tdata_reg;
-  assign m_axis_tvalid = int_tvalid_reg;
+  output_buffer #(
+    .DATA_WIDTH(AXIS_TDATA_WIDTH)
+  ) buf_0 (
+    .aclk(aclk), .aresetn(aresetn),
+    .in_data(s_axis_tdata), .in_valid(s_axis_tvalid & int_last_wire), .in_ready(s_axis_tready),
+    .out_data(m_axis_tdata), .out_valid(m_axis_tvalid), .out_ready(m_axis_tready)
+  );
 
 endmodule

--- a/cores/axis_decimator.v
+++ b/cores/axis_decimator.v
@@ -50,7 +50,7 @@ module axis_decimator #
   end
 
   assign int_comp_wire = int_cntr_reg < cfg_data;
-  assign int_tvalid_wire = int_tready_reg & s_axis_tvalid;
+  assign int_tvalid_wire = s_axis_tready & s_axis_tvalid;
 
   always @*
   begin
@@ -62,6 +62,11 @@ module axis_decimator #
     if(~int_tready_reg & int_comp_wire)
     begin
       int_tready_next = 1'b1;
+    end
+
+    if(m_axis_tready & int_tvalid_reg)
+    begin
+      int_tvalid_next = 1'b0;
     end
 
     if(int_tvalid_wire & int_comp_wire)
@@ -76,13 +81,9 @@ module axis_decimator #
       int_tvalid_next = 1'b1;
     end
 
-    if(m_axis_tready & int_tvalid_reg)
-    begin
-      int_tvalid_next = 1'b0;
-    end
   end
 
-  assign s_axis_tready = int_tready_reg;
+  assign s_axis_tready = int_tready_reg & (~int_tvalid_reg | m_axis_tready);
   assign m_axis_tdata = int_tdata_reg;
   assign m_axis_tvalid = int_tvalid_reg;
 

--- a/cores/axis_pulse_height_analyzer.v
+++ b/cores/axis_pulse_height_analyzer.v
@@ -26,34 +26,33 @@ module axis_pulse_height_analyzer #
   output wire [AXIS_TDATA_WIDTH-1:0]    m_axis_tdata,
   output wire                           m_axis_tvalid
 );
-  reg [AXIS_TDATA_WIDTH-1:0] int_data_reg[1:0], int_data_next[1:0];
-  reg [AXIS_TDATA_WIDTH-1:0] int_min_reg, int_min_next;
-  reg [AXIS_TDATA_WIDTH-1:0] int_tdata_reg, int_tdata_next;
-  reg [CNTR_WIDTH-1:0] int_cntr_reg, int_cntr_next;
-  reg int_enbl_reg, int_enbl_next;
-  reg int_rising_reg, int_rising_next;
-  reg int_tvalid_reg, int_tvalid_next;
 
-  wire [AXIS_TDATA_WIDTH-1:0] int_tdata_wire;
-  wire int_mincut_wire, int_maxcut_wire, int_rising_wire, int_delay_wire, int_tvalid_wire;
+  reg [AXIS_TDATA_WIDTH-1:0] int_data_reg[1:0];
+  reg [AXIS_TDATA_WIDTH-1:0] int_min_reg;
+  reg [CNTR_WIDTH-1:0] int_cntr_reg;
+  reg int_enbl_reg;
+  reg int_rising_reg;
+
+  wire [AXIS_TDATA_WIDTH-1:0] int_data_wire;
+  wire int_mincut_wire, int_maxcut_wire, int_rising_wire, int_delay_wire, int_valid_wire;
 
   assign int_delay_wire = int_cntr_reg < cfg_data;
-  assign int_tvalid_wire = s_axis_tvalid & s_axis_tready;
+  assign int_valid_wire = s_axis_tvalid & int_enbl_reg & int_rising_reg & ~int_rising_wire & int_mincut_wire & int_maxcut_wire;
 
   generate
     if(AXIS_TDATA_SIGNED == "TRUE")
     begin : SIGNED
       assign int_rising_wire = $signed(int_data_reg[1]) < $signed(s_axis_tdata);
-      assign int_tdata_wire = $signed(int_data_reg[0]) - $signed(int_min_reg);
-      assign int_mincut_wire = $signed(int_tdata_wire) > $signed(min_data);
-      assign int_maxcut_wire = $signed(int_tdata_wire) < $signed(max_data);
+      assign int_data_wire = $signed(int_data_reg[0]) - $signed(int_min_reg);
+      assign int_mincut_wire = $signed(int_data_wire) > $signed(min_data);
+      assign int_maxcut_wire = $signed(int_data_wire) < $signed(max_data);
     end
     else
     begin : UNSIGNED
       assign int_rising_wire = int_data_reg[1] < s_axis_tdata;
-      assign int_tdata_wire = int_data_reg[0] - int_min_reg;
-      assign int_mincut_wire = int_tdata_wire > min_data;
-      assign int_maxcut_wire = int_tdata_wire < max_data;
+      assign int_data_wire = int_data_reg[0] - int_min_reg;
+      assign int_mincut_wire = int_data_wire > min_data;
+      assign int_maxcut_wire = int_data_wire < max_data;
     end
   endgenerate
 
@@ -63,75 +62,44 @@ module axis_pulse_height_analyzer #
     begin
       int_data_reg[0] <= {(AXIS_TDATA_WIDTH){1'b0}};
       int_data_reg[1] <= {(AXIS_TDATA_WIDTH){1'b0}};
-      int_tdata_reg <= {(AXIS_TDATA_WIDTH){1'b0}};
       int_min_reg <= {(AXIS_TDATA_WIDTH){1'b0}};
       int_cntr_reg <= {(CNTR_WIDTH){1'b0}};
       int_enbl_reg <= 1'b0;
       int_rising_reg <= 1'b0;
-      int_tvalid_reg <= 1'b0;
     end
-    else
+    else if(s_axis_tvalid & s_axis_tready)
     begin
-      int_data_reg[0] <= int_data_next[0];
-      int_data_reg[1] <= int_data_next[1];
-      int_tdata_reg <= int_tdata_next;
-      int_min_reg <= int_min_next;
-      int_cntr_reg <= int_cntr_next;
-      int_enbl_reg <= int_enbl_next;
-      int_rising_reg <= int_rising_next;
-      int_tvalid_reg <= int_tvalid_next;
+      int_data_reg[0] <= s_axis_tdata;
+      int_data_reg[1] <= int_data_reg[0];
+      int_rising_reg <= int_rising_wire;
+
+      if(int_delay_wire)
+      begin
+        int_cntr_reg <= int_cntr_reg + 1'b1;
+      end
+
+      // minimum after delay
+      if(~int_delay_wire & ~int_rising_reg & int_rising_wire)
+      begin
+        int_min_reg <= int_data_reg[1];
+        int_enbl_reg <= 1'b1;
+      end
+
+      // maximum after minimum
+      if(int_enbl_reg & int_rising_reg & ~int_rising_wire & int_mincut_wire)
+      begin
+        int_cntr_reg <= {(CNTR_WIDTH){1'b0}};
+        int_enbl_reg <= 1'b0;
+      end
     end
   end
 
-  always @*
-  begin
-    int_data_next[0] = int_data_reg[0];
-    int_data_next[1] = int_data_reg[1];
-    int_tdata_next = int_tdata_reg;
-    int_min_next = int_min_reg;
-    int_cntr_next = int_cntr_reg;
-    int_enbl_next = int_enbl_reg;
-    int_rising_next = int_rising_reg;
-    int_tvalid_next = int_tvalid_reg;
-
-    if(m_axis_tready & int_tvalid_reg)
-    begin
-      int_tdata_next = {(AXIS_TDATA_WIDTH){1'b0}};
-      int_tvalid_next = 1'b0;
-    end
-
-    if(int_tvalid_wire)
-    begin
-      int_data_next[0] = s_axis_tdata;
-      int_data_next[1] = int_data_reg[0];
-      int_rising_next = int_rising_wire;
-    end
-
-    if(int_tvalid_wire & int_delay_wire)
-    begin
-      int_cntr_next = int_cntr_reg + 1'b1;
-    end
-
-    // minimum after delay
-    if(int_tvalid_wire & ~int_delay_wire & ~int_rising_reg & int_rising_wire)
-    begin
-      int_min_next = int_data_reg[1];
-      int_enbl_next = 1'b1;
-    end
-
-    // maximum after minimum
-    if(int_tvalid_wire & int_enbl_reg & int_rising_reg & ~int_rising_wire & int_mincut_wire)
-    begin
-      int_tdata_next = int_maxcut_wire ? int_tdata_wire : {(AXIS_TDATA_WIDTH){1'b0}};
-      int_tvalid_next = int_maxcut_wire;
-      int_cntr_next = {(CNTR_WIDTH){1'b0}};
-      int_enbl_next = 1'b0;
-    end
-
-  end
-
-  assign s_axis_tready = ~int_tvalid_reg | m_axis_tready;
-  assign m_axis_tdata = int_tdata_reg;
-  assign m_axis_tvalid = int_tvalid_reg;
+  output_buffer #(
+    .DATA_WIDTH(AXIS_TDATA_WIDTH)
+  ) buf_0 (
+    .aclk(aclk), .aresetn(aresetn),
+    .in_data(int_data_wire), .in_valid(int_valid_wire), .in_ready(s_axis_tready),
+    .out_data(m_axis_tdata), .out_valid(m_axis_tvalid), .out_ready(m_axis_tready)
+  );
 
 endmodule

--- a/cores/axis_pulse_height_analyzer.v
+++ b/cores/axis_pulse_height_analyzer.v
@@ -35,9 +35,10 @@ module axis_pulse_height_analyzer #
   reg int_tvalid_reg, int_tvalid_next;
 
   wire [AXIS_TDATA_WIDTH-1:0] int_tdata_wire;
-  wire int_mincut_wire, int_maxcut_wire, int_rising_wire, int_delay_wire;
+  wire int_mincut_wire, int_maxcut_wire, int_rising_wire, int_delay_wire, int_tvalid_wire;
 
   assign int_delay_wire = int_cntr_reg < cfg_data;
+  assign int_tvalid_wire = s_axis_tvalid & s_axis_tready;
 
   generate
     if(AXIS_TDATA_SIGNED == "TRUE")
@@ -93,27 +94,33 @@ module axis_pulse_height_analyzer #
     int_rising_next = int_rising_reg;
     int_tvalid_next = int_tvalid_reg;
 
-    if(s_axis_tvalid)
+    if(m_axis_tready & int_tvalid_reg)
+    begin
+      int_tdata_next = {(AXIS_TDATA_WIDTH){1'b0}};
+      int_tvalid_next = 1'b0;
+    end
+
+    if(int_tvalid_wire)
     begin
       int_data_next[0] = s_axis_tdata;
       int_data_next[1] = int_data_reg[0];
       int_rising_next = int_rising_wire;
     end
 
-    if(s_axis_tvalid & int_delay_wire)
+    if(int_tvalid_wire & int_delay_wire)
     begin
       int_cntr_next = int_cntr_reg + 1'b1;
     end
 
     // minimum after delay
-    if(s_axis_tvalid & ~int_delay_wire & ~int_rising_reg & int_rising_wire)
+    if(int_tvalid_wire & ~int_delay_wire & ~int_rising_reg & int_rising_wire)
     begin
       int_min_next = int_data_reg[1];
       int_enbl_next = 1'b1;
     end
 
     // maximum after minimum
-    if(s_axis_tvalid & int_enbl_reg & int_rising_reg & ~int_rising_wire & int_mincut_wire)
+    if(int_tvalid_wire & int_enbl_reg & int_rising_reg & ~int_rising_wire & int_mincut_wire)
     begin
       int_tdata_next = int_maxcut_wire ? int_tdata_wire : {(AXIS_TDATA_WIDTH){1'b0}};
       int_tvalid_next = int_maxcut_wire;
@@ -121,14 +128,9 @@ module axis_pulse_height_analyzer #
       int_enbl_next = 1'b0;
     end
 
-    if(m_axis_tready & int_tvalid_reg)
-    begin
-      int_tdata_next = {(AXIS_TDATA_WIDTH){1'b0}};
-      int_tvalid_next = 1'b0;
-    end
   end
 
-  assign s_axis_tready = 1'b1;
+  assign s_axis_tready = ~int_tvalid_reg | m_axis_tready;
   assign m_axis_tdata = int_tdata_reg;
   assign m_axis_tvalid = int_tvalid_reg;
 


### PR DESCRIPTION
These reduction cores continue accepting samples while a completed result is stalled. A later result can overwrite the pending payload; the decimator and continuous accumulator can also drop a replacement generated on the consuming cycle.

Backpressure each input while its output is occupied. Clear consumed state before processing a simultaneous input, allowing a newly completed result to remain valid.

Directed full-module probes cover overwrite and consume-and-replace traces for all three cores.
